### PR TITLE
[FIX] CloudFront 경로 대응을 위한 base 경로 설정

### DIFF
--- a/woorepie-front/vite.config.ts
+++ b/woorepie-front/vite.config.ts
@@ -5,6 +5,7 @@ import path from "path";
 export default defineConfig(({ command }) => {
   const isBuild = command === "build";
   return {
+    base: "/frontend/",
     plugins: [react()],
     resolve: {
       alias: {


### PR DESCRIPTION
## ✨ 작업 개요
CloudFront 경로(/frontend/)에서 정적 리소스 404 오류가 발생하는 문제를 해결하기 위해 vite.config.ts에 base 옵션을 추가했습니다.

## ✅ 작업 목록
- [x] Vite 설정 파일(vite.config.ts)에 base: '/frontend/' 옵션 추가
  - CloudFront 경로 기반에서 정적 파일 정상 로드되도록 번들 설정 조정
- [x] S3 /frontend 디렉토리에 업로드 후 브라우저 정상 렌더링 확인

## 📎 관련 이슈
- #15 