### PR TITLE
[FIX] vite.config.ts 파일 다시 원래대로 수정

### DIFF
--- a/woorepie-front/vite.config.ts
+++ b/woorepie-front/vite.config.ts
@@ -5,7 +5,6 @@ import path from "path";
 export default defineConfig(({ command }) => {
   const isBuild = command === "build";
   return {
-    base: "/frontend/",
     plugins: [react()],
     resolve: {
       alias: {


### PR DESCRIPTION
## ✨ 작업 개요
S3 버킷을 frontend용으로 새로 하나 만들고, CloudFront 정적 배포 경로를 루트("/")로 변경함에 따라 Vite 빌드 결과물이 경로 없이 접근 가능하도록 `base: '/'` 설정을 삭제하였습니다.

## ✅ 작업 목록
- [x] vite.config.ts 원래 코드로 변경

## 📎 관련 이슈
- #15 